### PR TITLE
Correção de tag GetIt.

### DIFF
--- a/example/lib/application/bindings/navigator_bindings.dart
+++ b/example/lib/application/bindings/navigator_bindings.dart
@@ -8,6 +8,12 @@ class MyNavigatorBindings extends NavigatorBindings {
         Bind.singleton(
           (i) => HomeController(),
           keepAlive: true,
+          tag: 'HomeController',
+        ),
+        Bind.singleton(
+          (i) => HomeController(),
+          keepAlive: true,
+          tag: 'HomeController2',
         ),
         Bind.lazySingleton<MyNavBarHelperController>(
           (i) => MyNavBarHelperController(),

--- a/example/lib/src/home/home_page.dart
+++ b/example/lib/src/home/home_page.dart
@@ -16,6 +16,8 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     log(_home1.toString());
     log(_home2.toString());
+    log(context.any<HomeController>().toString());
+
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/example/lib/src/home/home_page.dart
+++ b/example/lib/src/home/home_page.dart
@@ -9,11 +9,13 @@ import 'package:flutter_getit/flutter_getit.dart';
 class HomePage extends StatelessWidget {
   HomePage({super.key});
 
-  final _home = Injector.get<HomeController>();
+  final _home1 = Injector.get<HomeController>(tag: 'HomeController');
+  final _home2 = Injector.get<HomeController>(tag: 'HomeController2');
 
   @override
   Widget build(BuildContext context) {
-    log(_home.toString());
+    log(_home1.toString());
+    log(_home2.toString());
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0-rc.1"
+    version: "3.0.0-rc.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/core/flutter_getit_container_register.dart
+++ b/lib/src/core/flutter_getit_container_register.dart
@@ -55,7 +55,7 @@ final class FlutterGetItContainerRegister {
           )) {
         var unRegistered = [];
         for (var bind in register.bindings) {
-          final wasRegistered = bind.load(register.tag, debugMode);
+          final wasRegistered = bind.load(bind.tag, debugMode);
           if (!wasRegistered) {
             unRegistered.add(bind);
           }

--- a/lib/src/debug/debug_mode.dart
+++ b/lib/src/debug/debug_mode.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:developer';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
@@ -56,11 +55,12 @@ final class DebugMode {
 
   static fGetItLog(String data) {
     if (isEnable && !kReleaseMode) {
-      if (Platform.isIOS) {
-        log(data);
+      log(data, name: 'FGetIt');
+      /* if (Platform.isIOS) {
+        log(data, name: 'FGetIt');
       } else {
         debugPrint(data);
-      }
+      } */
     }
   }
 

--- a/lib/src/dependency_injector/binds/bind.dart
+++ b/lib/src/dependency_injector/binds/bind.dart
@@ -81,7 +81,7 @@ final class Bind<T extends Object> {
       return false;
     }
     DebugMode.fGetItLog(
-        '📠$blueColor Registering: $T$yellowColor as$blueColor ${type.name}${keepAlive ? '$yellowColor with$blueColor keepAlive' : ''}');
+        '📠$blueColor Registering: $T$yellowColor as$blueColor ${type.name}${keepAlive ? '$yellowColor with$blueColor keepAlive' : ''}${tag == null ? '' : '$yellowColor and tag:$blueColor $tag'}');
     switch (type) {
       case RegisterType.singleton:
         getIt.registerSingleton<T>(

--- a/lib/src/dependency_injector/binds/bind.dart
+++ b/lib/src/dependency_injector/binds/bind.dart
@@ -153,7 +153,7 @@ final class Bind<T extends Object> {
             (entity as FlutterGetItMixin).onDispose();
           }
           DebugMode.fGetItLog(
-              '🚮$yellowColor Dispose: $T (${type.name}) - ${entity.hashCode}');
+              '🚮$yellowColor Dispose: $T (${type.name}) - ${entity.hashCode}${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
 
           runOnDisposingFunction = true;
           return;
@@ -162,7 +162,7 @@ final class Bind<T extends Object> {
 
       if (isFactory && isTheFactoryDad || !runOnDisposingFunction) {
         DebugMode.fGetItLog(
-            '🚮$yellowColor Dispose: $T (${type.name}) - ${T.hashCode}');
+            '🚮$yellowColor Dispose: $T (${type.name}) - ${T.hashCode}${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
       }
 
       return;

--- a/lib/src/dependency_injector/injector.dart
+++ b/lib/src/dependency_injector/injector.dart
@@ -21,6 +21,10 @@ class Injector {
     return GetIt.I.isRegistered<T>(instanceName: tag);
   }
 
+  static bool any<T extends Object>() {
+    return GetIt.I.getAll<T>().isNotEmpty;
+  }
+
   /// Get para recupera a instancia do GetIt
   static T get<T extends Object>({String? tag, String? factoryTag}) {
     try {
@@ -99,4 +103,6 @@ extension InjectorContext on BuildContext {
 
   bool isRegistered<T extends Object>({String? tag}) =>
       Injector.isRegistered<T>(tag: tag);
+
+  bool any<T extends Object>() => Injector.any<T>();
 }

--- a/lib/src/dependency_injector/injector.dart
+++ b/lib/src/dependency_injector/injector.dart
@@ -17,6 +17,10 @@ class Injector {
     FlutterGetItBindingOpened.unRegisterFactories<T>();
   }
 
+  static bool isRegistered<T extends Object>({String? tag}) {
+    return GetIt.I.isRegistered<T>(instanceName: tag);
+  }
+
   /// Get para recupera a instancia do GetIt
   static T get<T extends Object>({String? tag, String? factoryTag}) {
     try {
@@ -34,7 +38,8 @@ class Injector {
       final containsHash = FlutterGetItBindingOpened.contains(obj.hashCode);
       if (!(T == FlutterGetItContainerRegister || T == FlutterGetItContext) &&
           !containsHash) {
-        DebugMode.fGetItLog('🎣$cyanColor Getting: $T - ${obj.hashCode}');
+        DebugMode.fGetItLog(
+            '🎣$cyanColor Getting: $T - ${obj.hashCode}${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
       }
 
       if (containsFactoryDad) {
@@ -47,7 +52,7 @@ class Injector {
       FlutterGetItBindingOpened.registerHashCodeOpened(obj.hashCode);
       return obj;
     } on AssertionError catch (e) {
-      log('⛔️$redColor Error on get: $T\n$yellowColor${e.message.toString()}');
+      log('⛔️$redColor Error on get: $T\n$yellowColor${e.message.toString()}${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
 
       throw Exception('${T.toString()} not found in injector}');
     }
@@ -56,15 +61,17 @@ class Injector {
   static Future<T> getAsync<T extends Object>(
       {String? tag, String? factoryTag}) async {
     try {
-      DebugMode.fGetItLog('🎣🥱$yellowColor Getting async: $T');
+      DebugMode.fGetItLog(
+          '🎣🥱$yellowColor Getting async: $T${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
 
       return await GetIt.I.isReady<T>(instanceName: tag).then((_) {
-        DebugMode.fGetItLog('🎣😎$greenColor $T ready');
+        DebugMode.fGetItLog(
+            '🎣😎$greenColor $T${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''} ready');
 
         return get<T>(tag: tag, factoryTag: factoryTag);
       });
     } on AssertionError catch (e) {
-      log('⛔️$redColor Error on get async: $T\n$yellowColor${e.message.toString()}');
+      log('⛔️$redColor Error on get async: $T\n$yellowColor${e.message.toString()}${tag != null ? '$yellowColor with tag:$cyanColor $tag' : ''}');
 
       throw Exception('${T.toString()} not found in injector}');
     }
@@ -89,4 +96,7 @@ class Injector {
 extension InjectorContext on BuildContext {
   T get<T extends Object>({String? tag, String? factoryTag}) =>
       Injector.get<T>(tag: tag, factoryTag: factoryTag);
+
+  bool isRegistered<T extends Object>({String? tag}) =>
+      Injector.isRegistered<T>(tag: tag);
 }


### PR DESCRIPTION
Corrigido injecção utilizando tag.
No trecho de código abaixo, onde está sublinhado, estava a repassar o register.tag, o que causava erro no GetIt por registar com tag errada, corrigido alterando para `bind.tag`.

Testes via home no exemplo atualizados.

![Screenshot 2024-08-02 at 10 26 56](https://github.com/user-attachments/assets/ce3da286-89ca-4cd9-b7ba-d15bf0c8cd0c)

Log:
![Screenshot 2024-08-02 at 10 29 36](https://github.com/user-attachments/assets/36248376-7609-4fbe-8c19-352983c33f98)


