### PR TITLE
Correção singleton

### DIFF
--- a/example/lib/src/nav_bar/my_nav_bar.dart
+++ b/example/lib/src/nav_bar/my_nav_bar.dart
@@ -36,7 +36,7 @@ class _MyNavBarState extends State<MyNavBar> {
       body: FlutterGetIt.navigator(
         name: 'NAVbarProducts',
         bindings: MyNavigatorBindings(),
-        pagesRouter: [
+        modulesRouter: [
           FlutterGetItModuleRouter(
             name: '/Random',
             bindings: [

--- a/lib/src/dependency_injector/binds/bind.dart
+++ b/lib/src/dependency_injector/binds/bind.dart
@@ -183,15 +183,27 @@ final class Bind<T extends Object> {
     switch (type) {
       case RegisterType.singleton:
         if (dependsOn.isEmpty) {
+          final obj = bindRegister!(Injector());
+          if (hasMixin<FlutterGetItMixin>(obj)) {
+            (obj as dynamic).onInit();
+          }
+          FlutterGetItBindingOpened.registerHashCodeOpened(obj.hashCode);
           getIt.registerSingleton<T>(
-            bindRegister!(Injector()),
+            obj,
             instanceName: tag,
             dispose: (entity) => null,
             signalsReady: false,
           );
         } else {
           getIt.registerSingletonWithDependencies<T>(
-            () => bindRegister!(Injector()),
+            () {
+              final obj = bindRegister!(Injector());
+              if (hasMixin<FlutterGetItMixin>(obj)) {
+                (obj as dynamic).onInit();
+              }
+              FlutterGetItBindingOpened.registerHashCodeOpened(obj.hashCode);
+              return obj;
+            },
             instanceName: tag,
             dispose: (entity) => null,
             dependsOn: dependsOn,
@@ -206,7 +218,14 @@ final class Bind<T extends Object> {
         );
       case RegisterType.singletonAsync:
         getIt.registerSingletonAsync<T>(
-          () async => await bindAsyncRegister!(Injector()),
+          () async {
+            final obj = await bindAsyncRegister!(Injector());
+            if (hasMixin<FlutterGetItMixin>(obj)) {
+              (obj as dynamic).onInit();
+            }
+            FlutterGetItBindingOpened.registerHashCodeOpened(obj.hashCode);
+            return obj;
+          },
           instanceName: tag,
           dispose: (entity) => null,
           dependsOn: dependsOn,


### PR DESCRIPTION
Correção singleton com abertura do object que usa o FlutterGetItMixin, e salvamento da hash.


A hash salva garante que a verificação não é feita mais de uma vez.

Antes apenas verificávamos no "get", o que quebrava o conceito singleton que era criado no momento.
Ex, eu poderia criar o singleton, e só chamá-lo depois, assim o onInit só era chamado ali.

Agora executamos na função enviada ao GetIt, rodando o onInit se necessário, e salvando a hash.